### PR TITLE
fix(home): 粘贴混合分享文本时提取纯链接再入队

### DIFF
--- a/app/src/main/java/com/jk/offermate/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/jk/offermate/ui/home/HomeViewModel.kt
@@ -59,8 +59,11 @@ class HomeViewModel(
     }
 
     fun onExtract() {
-        val link = _uiState.value.linkInput.trim()
-        if (link.isEmpty()) return
+        val input = _uiState.value.linkInput.trim()
+        if (input.isEmpty()) return
+        // 用户可能粘贴的是"标题 + 链接 + 推广文案"整段分享文本（如小红书分享），
+        // 而非纯链接；这里统一用 ShareIntentParser 提取出真正的链接，避免把整段文本当 URL 打开失败。
+        val link = ShareIntentParser.extractLink(input) ?: input
         viewModelScope.launch {
             if (!canAnalyze()) return@launch
             importScheduler.enqueueUrl(link)

--- a/app/src/test/java/com/jk/offermate/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/jk/offermate/ui/home/HomeViewModelTest.kt
@@ -115,6 +115,20 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `extract with title and link mixed text extracts pure link`() {
+        val scheduler = FakeImportScheduler()
+        val vm = viewModel(scheduler)
+        vm.onLinkChange(
+            "拼多多客户端二面凉经 深深的八股拷打，答不上来的题... https://xhslink.cn/o/8XYgQ9UCwdT " +
+                "先复制再打开【小红书】，精彩内容等你翻阅。"
+        )
+
+        vm.onExtract()
+
+        assertEquals(listOf("https://xhslink.cn/o/8XYgQ9UCwdT"), scheduler.urls)
+    }
+
+    @Test
     fun `paste analyze enqueues text`() {
         val scheduler = FakeImportScheduler()
         val vm = viewModel(scheduler)


### PR DESCRIPTION
链接输入框走 onExtract() 时未做与分享 Intent 相同的链接提取，
用户粘贴“标题+链接+推广文案”的整段分享文本会把全文当作 URL 打开导致解析失败。
复用 ShareIntentParser.extractLink 统一处理。